### PR TITLE
Python dependency note for shaderc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ for your IDE (e.g. Visual Studio or XCode) in the chosen build
 directory. Open them, compile the target 'BUILD_ALL'. Also build
 the target 'install'.
 
+**Note: Python 3.X is required to build the "shaderc" project.** Download link: [Python 3.X](https://www.python.org/downloads/)
+
 USAGE
 =======
 


### PR DESCRIPTION
Just a simple note to let users know that Python 3.X is needed to build the shaderc project.