### PR TITLE
Replace dynamic exception specifications with noexecept

### DIFF
--- a/src/FreeImage/Source/OpenEXR/Imath/ImathMatrix.h
+++ b/src/FreeImage/Source/OpenEXR/Imath/ImathMatrix.h
@@ -261,16 +261,16 @@ template <class T> class Matrix33
     //------------------------------------------------------------
 
     const Matrix33 &    invert (bool singExc = false)
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     Matrix33<T>         inverse (bool singExc = false) const
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     const Matrix33 &    gjInvert (bool singExc = false)
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     Matrix33<T>         gjInverse (bool singExc = false) const
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
 
     //-----------------------------------------
@@ -605,16 +605,16 @@ template <class T> class Matrix44
     //------------------------------------------------------------
 
     const Matrix44 &    invert (bool singExc = false)
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     Matrix44<T>         inverse (bool singExc = false) const
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     const Matrix44 &    gjInvert (bool singExc = false)
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
     Matrix44<T>         gjInverse (bool singExc = false) const
-                        throw (Iex::MathExc);
+                        noexcept(false);
 
 
     //--------------------------------------------------------
@@ -1369,7 +1369,7 @@ Matrix33<T>::transposed () const
 
 template <class T>
 const Matrix33<T> &
-Matrix33<T>::gjInvert (bool singExc) throw (Iex::MathExc)
+Matrix33<T>::gjInvert (bool singExc) noexcept(false)
 {
     *this = gjInverse (singExc);
     return *this;
@@ -1377,7 +1377,7 @@ Matrix33<T>::gjInvert (bool singExc) throw (Iex::MathExc)
 
 template <class T>
 Matrix33<T>
-Matrix33<T>::gjInverse (bool singExc) const throw (Iex::MathExc)
+Matrix33<T>::gjInverse (bool singExc) const noexcept(false)
 {
     int i, j, k;
     Matrix33 s;
@@ -1481,7 +1481,7 @@ Matrix33<T>::gjInverse (bool singExc) const throw (Iex::MathExc)
 
 template <class T>
 const Matrix33<T> &
-Matrix33<T>::invert (bool singExc) throw (Iex::MathExc)
+Matrix33<T>::invert (bool singExc) noexcept(false)
 {
     *this = inverse (singExc);
     return *this;
@@ -1489,7 +1489,7 @@ Matrix33<T>::invert (bool singExc) throw (Iex::MathExc)
 
 template <class T>
 Matrix33<T>
-Matrix33<T>::inverse (bool singExc) const throw (Iex::MathExc)
+Matrix33<T>::inverse (bool singExc) const noexcept(false)
 {
     if (x[0][2] != 0 || x[1][2] != 0 || x[2][2] != 1)
     {
@@ -2609,7 +2609,7 @@ Matrix44<T>::transposed () const
 
 template <class T>
 const Matrix44<T> &
-Matrix44<T>::gjInvert (bool singExc) throw (Iex::MathExc)
+Matrix44<T>::gjInvert (bool singExc) noexcept(false)
 {
     *this = gjInverse (singExc);
     return *this;
@@ -2617,7 +2617,7 @@ Matrix44<T>::gjInvert (bool singExc) throw (Iex::MathExc)
 
 template <class T>
 Matrix44<T>
-Matrix44<T>::gjInverse (bool singExc) const throw (Iex::MathExc)
+Matrix44<T>::gjInverse (bool singExc) const noexcept(false)
 {
     int i, j, k;
     Matrix44 s;
@@ -2721,7 +2721,7 @@ Matrix44<T>::gjInverse (bool singExc) const throw (Iex::MathExc)
 
 template <class T>
 const Matrix44<T> &
-Matrix44<T>::invert (bool singExc) throw (Iex::MathExc)
+Matrix44<T>::invert (bool singExc) noexcept(false)
 {
     *this = inverse (singExc);
     return *this;
@@ -2729,7 +2729,7 @@ Matrix44<T>::invert (bool singExc) throw (Iex::MathExc)
 
 template <class T>
 Matrix44<T>
-Matrix44<T>::inverse (bool singExc) const throw (Iex::MathExc)
+Matrix44<T>::inverse (bool singExc) const noexcept(false)
 {
     if (x[0][3] != 0 || x[1][3] != 0 || x[2][3] != 0 || x[3][3] != 1)
         return gjInverse(singExc);

--- a/src/FreeImage/Source/OpenEXR/Imath/ImathVec.cpp
+++ b/src/FreeImage/Source/OpenEXR/Imath/ImathVec.cpp
@@ -145,7 +145,7 @@ Vec2<short>::normalize ()
 
 template <>
 const Vec2<short> &
-Vec2<short>::normalizeExc () throw (Iex::MathExc)
+Vec2<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -173,7 +173,7 @@ Vec2<short>::normalized () const
 
 template <>
 Vec2<short>
-Vec2<short>::normalizedExc () const throw (Iex::MathExc)
+Vec2<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -214,7 +214,7 @@ Vec2<int>::normalize ()
 
 template <>
 const Vec2<int> &
-Vec2<int>::normalizeExc () throw (Iex::MathExc)
+Vec2<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -242,7 +242,7 @@ Vec2<int>::normalized () const
 
 template <>
 Vec2<int>
-Vec2<int>::normalizedExc () const throw (Iex::MathExc)
+Vec2<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -283,7 +283,7 @@ Vec3<short>::normalize ()
 
 template <>
 const Vec3<short> &
-Vec3<short>::normalizeExc () throw (Iex::MathExc)
+Vec3<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -311,7 +311,7 @@ Vec3<short>::normalized () const
 
 template <>
 Vec3<short>
-Vec3<short>::normalizedExc () const throw (Iex::MathExc)
+Vec3<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -352,7 +352,7 @@ Vec3<int>::normalize ()
 
 template <>
 const Vec3<int> &
-Vec3<int>::normalizeExc () throw (Iex::MathExc)
+Vec3<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -380,7 +380,7 @@ Vec3<int>::normalized () const
 
 template <>
 Vec3<int>
-Vec3<int>::normalizedExc () const throw (Iex::MathExc)
+Vec3<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -421,7 +421,7 @@ Vec4<short>::normalize ()
 
 template <>
 const Vec4<short> &
-Vec4<short>::normalizeExc () throw (Iex::MathExc)
+Vec4<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -449,7 +449,7 @@ Vec4<short>::normalized () const
 
 template <>
 Vec4<short>
-Vec4<short>::normalizedExc () const throw (Iex::MathExc)
+Vec4<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -490,7 +490,7 @@ Vec4<int>::normalize ()
 
 template <>
 const Vec4<int> &
-Vec4<int>::normalizeExc () throw (Iex::MathExc)
+Vec4<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -518,7 +518,7 @@ Vec4<int>::normalized () const
 
 template <>
 Vec4<int>
-Vec4<int>::normalizedExc () const throw (Iex::MathExc)
+Vec4<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");

--- a/src/FreeImage/Source/OpenEXR/Imath/ImathVec.h
+++ b/src/FreeImage/Source/OpenEXR/Imath/ImathVec.h
@@ -224,11 +224,11 @@ template <class T> class Vec2
     T			length2 () const;
 
     const Vec2 &	normalize ();           // modifies *this
-    const Vec2 &	normalizeExc () throw (Iex::MathExc);
+    const Vec2 &	normalizeExc () noexcept(false);
     const Vec2 &	normalizeNonNull ();
 
     Vec2<T>		normalized () const;	// does not modify *this
-    Vec2<T>		normalizedExc () const throw (Iex::MathExc);
+    Vec2<T>		normalizedExc () const noexcept(false);
     Vec2<T>		normalizedNonNull () const;
 
 
@@ -436,11 +436,11 @@ template <class T> class Vec3
     T			length2 () const;
 
     const Vec3 &	normalize ();           // modifies *this
-    const Vec3 &	normalizeExc () throw (Iex::MathExc);
+    const Vec3 &	normalizeExc () noexcept(false);
     const Vec3 &	normalizeNonNull ();
 
     Vec3<T>		normalized () const;	// does not modify *this
-    Vec3<T>		normalizedExc () const throw (Iex::MathExc);
+    Vec3<T>		normalizedExc () const noexcept(false);
     Vec3<T>		normalizedNonNull () const;
 
 
@@ -618,11 +618,11 @@ template <class T> class Vec4
     T               length2 () const;
 
     const Vec4 &    normalize ();           // modifies *this
-    const Vec4 &    normalizeExc () throw (Iex::MathExc);
+    const Vec4 &    normalizeExc () noexcept(false);
     const Vec4 &    normalizeNonNull ();
 
     Vec4<T>         normalized () const;	// does not modify *this
-    Vec4<T>         normalizedExc () const throw (Iex::MathExc);
+    Vec4<T>         normalizedExc () const noexcept(false);
     Vec4<T>         normalizedNonNull () const;
 
 
@@ -710,7 +710,7 @@ template <> const Vec2<short> &
 Vec2<short>::normalize ();
 
 template <> const Vec2<short> &
-Vec2<short>::normalizeExc () throw (Iex::MathExc);
+Vec2<short>::normalizeExc () noexcept(false);
 
 template <> const Vec2<short> &
 Vec2<short>::normalizeNonNull ();
@@ -719,7 +719,7 @@ template <> Vec2<short>
 Vec2<short>::normalized () const;
 
 template <> Vec2<short>
-Vec2<short>::normalizedExc () const throw (Iex::MathExc);
+Vec2<short>::normalizedExc () const noexcept(false);
 
 template <> Vec2<short>
 Vec2<short>::normalizedNonNull () const;
@@ -734,7 +734,7 @@ template <> const Vec2<int> &
 Vec2<int>::normalize ();
 
 template <> const Vec2<int> &
-Vec2<int>::normalizeExc () throw (Iex::MathExc);
+Vec2<int>::normalizeExc () noexcept(false);
 
 template <> const Vec2<int> &
 Vec2<int>::normalizeNonNull ();
@@ -743,7 +743,7 @@ template <> Vec2<int>
 Vec2<int>::normalized () const;
 
 template <> Vec2<int>
-Vec2<int>::normalizedExc () const throw (Iex::MathExc);
+Vec2<int>::normalizedExc () const noexcept(false);
 
 template <> Vec2<int>
 Vec2<int>::normalizedNonNull () const;
@@ -758,7 +758,7 @@ template <> const Vec3<short> &
 Vec3<short>::normalize ();
 
 template <> const Vec3<short> &
-Vec3<short>::normalizeExc () throw (Iex::MathExc);
+Vec3<short>::normalizeExc () noexcept(false);
 
 template <> const Vec3<short> &
 Vec3<short>::normalizeNonNull ();
@@ -767,7 +767,7 @@ template <> Vec3<short>
 Vec3<short>::normalized () const;
 
 template <> Vec3<short>
-Vec3<short>::normalizedExc () const throw (Iex::MathExc);
+Vec3<short>::normalizedExc () const noexcept(false);
 
 template <> Vec3<short>
 Vec3<short>::normalizedNonNull () const;
@@ -782,7 +782,7 @@ template <> const Vec3<int> &
 Vec3<int>::normalize ();
 
 template <> const Vec3<int> &
-Vec3<int>::normalizeExc () throw (Iex::MathExc);
+Vec3<int>::normalizeExc () noexcept(false);
 
 template <> const Vec3<int> &
 Vec3<int>::normalizeNonNull ();
@@ -791,7 +791,7 @@ template <> Vec3<int>
 Vec3<int>::normalized () const;
 
 template <> Vec3<int>
-Vec3<int>::normalizedExc () const throw (Iex::MathExc);
+Vec3<int>::normalizedExc () const noexcept(false);
 
 template <> Vec3<int>
 Vec3<int>::normalizedNonNull () const;
@@ -805,7 +805,7 @@ template <> const Vec4<short> &
 Vec4<short>::normalize ();
 
 template <> const Vec4<short> &
-Vec4<short>::normalizeExc () throw (Iex::MathExc);
+Vec4<short>::normalizeExc () noexcept(false);
 
 template <> const Vec4<short> &
 Vec4<short>::normalizeNonNull ();
@@ -814,7 +814,7 @@ template <> Vec4<short>
 Vec4<short>::normalized () const;
 
 template <> Vec4<short>
-Vec4<short>::normalizedExc () const throw (Iex::MathExc);
+Vec4<short>::normalizedExc () const noexcept(false);
 
 template <> Vec4<short>
 Vec4<short>::normalizedNonNull () const;
@@ -829,7 +829,7 @@ template <> const Vec4<int> &
 Vec4<int>::normalize ();
 
 template <> const Vec4<int> &
-Vec4<int>::normalizeExc () throw (Iex::MathExc);
+Vec4<int>::normalizeExc () noexcept(false);
 
 template <> const Vec4<int> &
 Vec4<int>::normalizeNonNull ();
@@ -838,7 +838,7 @@ template <> Vec4<int>
 Vec4<int>::normalized () const;
 
 template <> Vec4<int>
-Vec4<int>::normalizedExc () const throw (Iex::MathExc);
+Vec4<int>::normalizedExc () const noexcept(false);
 
 template <> Vec4<int>
 Vec4<int>::normalizedNonNull () const;
@@ -1208,7 +1208,7 @@ Vec2<T>::normalize ()
 
 template <class T>
 const Vec2<T> &
-Vec2<T>::normalizeExc () throw (Iex::MathExc)
+Vec2<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -1245,7 +1245,7 @@ Vec2<T>::normalized () const
 
 template <class T>
 Vec2<T>
-Vec2<T>::normalizedExc () const throw (Iex::MathExc)
+Vec2<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 
@@ -1700,7 +1700,7 @@ Vec3<T>::normalize ()
 
 template <class T>
 const Vec3<T> &
-Vec3<T>::normalizeExc () throw (Iex::MathExc)
+Vec3<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -1739,7 +1739,7 @@ Vec3<T>::normalized () const
 
 template <class T>
 Vec3<T>
-Vec3<T>::normalizedExc () const throw (Iex::MathExc)
+Vec3<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 
@@ -2105,7 +2105,7 @@ Vec4<T>::normalize ()
 
 template <class T>
 const Vec4<T> &
-Vec4<T>::normalizeExc () throw (Iex::MathExc)
+Vec4<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -2146,7 +2146,7 @@ Vec4<T>::normalized () const
 
 template <class T>
 Vec4<T>
-Vec4<T>::normalizedExc () const throw (Iex::MathExc)
+Vec4<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 


### PR DESCRIPTION
ISO C++17 does not allow dynamic exception specifications

Proposed fix for #6 

`
noexcept is an improved version of throw(), which is deprecated in C++11. Unlike pre-C++17 throw(), noexcept will not call std::unexpected and may or may not unwind the stack, which potentially allows the compiler to implement noexcept without the runtime overhead of throw(). As of C++17, throw() is redefined to be an exact equivalent of noexcept(true). ` -- https://en.cppreference.com/w/cpp/language/noexcept_spec

Compiles fine after replacing usages of `throw` with the equivalent `noexcept` specifier